### PR TITLE
Add ViGEm support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "Client/ViGEmClient"]
+	path = Client/ViGEmClient
+	url = https://github.com/ViGEm/ViGEmClient.git

--- a/Client/Makefile
+++ b/Client/Makefile
@@ -19,11 +19,31 @@ all: linux
     endif
 endif
 
-windows:
+ViGEmClient.o: ViGEmClient/src/ViGEmClient.cpp
+	g++ -c \
+		-static -static-libgcc -static-libstdc++ \
+		-I ViGEmClient/include \
+		-municode -DERROR_INVALID_DEVICE_OBJECT_PARAMETER=650L\
+		ViGEmClient/src/ViGEmClient.cpp
+
+tinyxml2.o: tinyxml2.cpp
+	g++ -c \
+		-static -static-libgcc -static-libstdc++ \
+		tinyxml2.cpp
+
+icon.res: icon.rc
 	windres icon.rc -O coff -o icon.res
-	g++ -static-libgcc -static-libstdc++ -o VitaPad main.cpp tinyxml2.cpp icon.res -I VJoySDK/inc $(VJOY_LIB_PATH)/vJoyInterface.lib -static -lpthread -lws2_32 -fpermissive
+
+vJoyInterface.dll: $(VJOY_LIB_PATH)/vJoyInterface.dll
 # use powershell to handle Linux-style file path, cmd will not work
 	powershell -Command Copy-Item -Path $(VJOY_LIB_PATH)/vJoyInterface.dll -Destination vJoyInterface.dll
 
-linux:
-	g++ -static-libgcc -static-libstdc++ -o VitaPad main.cpp tinyxml2.cpp -lX11 -lXtst -fpermissive
+windows: ViGEmClient.o tinyxml2.o icon.res vJoyInterface.dll
+	g++ -static -static-libgcc -static-libstdc++ \
+		-I VJoySDK/inc -I ViGEmClient/include \
+		-o VitaPad \
+		main.cpp ViGEm.cpp ViGEmClient.o tinyxml2.o icon.res \
+		 $(VJOY_LIB_PATH)/vJoyInterface.lib -lpthread -lws2_32 -lsetupapi
+
+linux: tinyxml2.o
+	g++ -static-libgcc -static-libstdc++ -o VitaPad main.cpp tinyxml2.o -lX11 -lXtst

--- a/Client/ViGEm.cpp
+++ b/Client/ViGEm.cpp
@@ -1,0 +1,101 @@
+#include <Windows.h>
+
+#include "ViGEm.h"
+
+PVIGEM_CLIENT client;
+PVIGEM_TARGET target;
+
+void vgDestroy()
+{
+    vigem_target_remove(client, target);
+    vigem_target_free(target);
+    target = NULL;
+
+    vigem_disconnect(client);
+    vigem_free(client);
+    client = NULL;
+}
+
+bool vgInit()
+{
+    do
+    {
+        if (NULL == (client = vigem_alloc())) break;
+        if (!VIGEM_SUCCESS(vigem_connect(client))) break;
+        if (NULL == (target = vigem_target_ds4_alloc())) break;
+        if (!VIGEM_SUCCESS(vigem_target_add(client, target))) break;
+        return true;
+    } while (false);
+    vgDestroy();
+    return false;
+}
+
+bool vgSubmit(pPadPacket packet)
+{
+    DS4_REPORT report;
+    DS4_REPORT_INIT(&report);
+
+    report.bThumbLX = packet->lx;
+    report.bThumbLY = packet->ly;
+    report.bThumbRX = packet->rx;
+    report.bThumbRY = packet->ry;
+
+    if (packet->buttons & SCE_CTRL_SELECT)
+    {
+        report.wButtons = report.wButtons | DS4_BUTTON_OPTIONS;
+    }
+    if (packet->buttons & SCE_CTRL_START)
+    {
+        report.wButtons = report.wButtons | DS4_BUTTON_SHARE;
+    }
+    if (packet->buttons & SCE_CTRL_LTRIGGER)
+    {
+        report.wButtons = report.wButtons | DS4_BUTTON_TRIGGER_LEFT;
+        report.bTriggerL = 0xFF;
+    }
+    if (packet->buttons & SCE_CTRL_RTRIGGER)
+    {
+        report.wButtons = report.wButtons | DS4_BUTTON_TRIGGER_RIGHT;
+        report.bTriggerR = 0xFF;
+    }
+    if (packet->buttons & SCE_CTRL_TRIANGLE)
+    {
+        report.wButtons = report.wButtons | DS4_BUTTON_TRIANGLE;
+    }
+    if (packet->buttons & SCE_CTRL_CIRCLE)
+    {
+        report.wButtons = report.wButtons | DS4_BUTTON_CIRCLE;
+    }
+    if (packet->buttons & SCE_CTRL_CROSS)
+    {
+        report.wButtons = report.wButtons | DS4_BUTTON_CROSS;
+    }
+    if (packet->buttons & SCE_CTRL_SQUARE)
+    {
+        report.wButtons = report.wButtons | DS4_BUTTON_SQUARE;
+    }
+    if (packet->click & MOUSE_MOV && packet->tx < SCREEN_WIDTH / 2)
+    {
+        report.wButtons = report.wButtons | DS4_BUTTON_SHOULDER_LEFT;
+    }
+    if (packet->click & MOUSE_MOV && packet->tx >= SCREEN_WIDTH / 2)
+    {
+        report.wButtons = report.wButtons | DS4_BUTTON_SHOULDER_RIGHT;
+    }
+
+    if (packet->buttons & SCE_CTRL_UP) DS4_SET_DPAD(&report, DS4_BUTTON_DPAD_NORTH);
+    if (packet->buttons & SCE_CTRL_RIGHT) DS4_SET_DPAD(&report, DS4_BUTTON_DPAD_EAST);
+    if (packet->buttons & SCE_CTRL_DOWN) DS4_SET_DPAD(&report, DS4_BUTTON_DPAD_SOUTH);
+    if (packet->buttons & SCE_CTRL_LEFT) DS4_SET_DPAD(&report, DS4_BUTTON_DPAD_WEST);
+
+    if (packet->buttons & SCE_CTRL_UP
+        && packet->buttons & SCE_CTRL_RIGHT) DS4_SET_DPAD(&report, DS4_BUTTON_DPAD_NORTHEAST);
+    if (packet->buttons & SCE_CTRL_RIGHT
+        && packet->buttons & SCE_CTRL_DOWN) DS4_SET_DPAD(&report, DS4_BUTTON_DPAD_SOUTHEAST);
+    if (packet->buttons & SCE_CTRL_DOWN
+        && packet->buttons & SCE_CTRL_LEFT) DS4_SET_DPAD(&report, DS4_BUTTON_DPAD_SOUTHWEST);
+    if (packet->buttons & SCE_CTRL_LEFT
+        && packet->buttons & SCE_CTRL_UP) DS4_SET_DPAD(&report, DS4_BUTTON_DPAD_NORTHWEST);
+    
+    return VIGEM_SUCCESS(vigem_target_ds4_update(client, target, report));
+}

--- a/Client/ViGEm.h
+++ b/Client/ViGEm.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "ViGEm/Client.h"
+
+#include "main.h"
+
+enum {
+    VIGEM_DEVICE_NONE   = 0,
+    VIGEM_DEVICE_DS4    = 1,
+} VIGEM_DEVICE;
+
+void vgDestroy();
+bool vgInit();
+bool vgSubmit(pPadPacket packet);

--- a/Client/main.h
+++ b/Client/main.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <stdint.h>
+
+// PSVITA related stuffs
+#define SCREEN_WIDTH 1920
+#define SCREEN_HEIGHT 1088
+
+enum {
+	SCE_CTRL_SELECT     = 0x000001,	//!< Select button.
+	SCE_CTRL_START      = 0x000008,	//!< Start button.
+	SCE_CTRL_UP         = 0x000010,	//!< Up D-Pad button.
+	SCE_CTRL_RIGHT      = 0x000020,	//!< Right D-Pad button.
+	SCE_CTRL_DOWN       = 0x000040,	//!< Down D-Pad button.
+	SCE_CTRL_LEFT       = 0x000080,	//!< Left D-Pad button.
+	SCE_CTRL_LTRIGGER   = 0x000100,	//!< Left trigger.
+	SCE_CTRL_RTRIGGER   = 0x000200,	//!< Right trigger.
+	SCE_CTRL_TRIANGLE   = 0x001000,	//!< Triangle button.
+	SCE_CTRL_CIRCLE     = 0x002000,	//!< Circle button.
+	SCE_CTRL_CROSS      = 0x004000,	//!< Cross button.
+	SCE_CTRL_SQUARE     = 0x008000	//!< Square button.
+};
+
+// Touchpad const
+#define NO_INPUT 0
+#define MOUSE_MOV 0x01
+#define LEFT_CLICK 0x08
+#define RIGHT_CLICK 0x10
+
+// Server packet
+typedef struct{
+	uint32_t buttons;
+	uint8_t lx;
+	uint8_t ly;
+	uint8_t rx;
+	uint8_t ry;
+	uint16_t tx;
+	uint16_t ty;
+	uint8_t click;
+} PadPacket, *pPadPacket;

--- a/Client/windows.xml
+++ b/Client/windows.xml
@@ -1,5 +1,6 @@
 <!-- If you want to change mapping, look here: http://www.philipstorr.id.au/pcbook/book3/scancode.htm -->
 
+<VIGEM_MODE>0</VIGEM_MODE>
 <VJOY_MODE>0</VJOY_MODE>
 <VJOY_ALTERNATE>0</VJOY_ALTERNATE>
 <KEY_DOWN>0x1F</KEY_DOWN>

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ VitaPad allows you to use your PSVITA as a wireless PC controller. It supports W
 
 * Install VPK file on PSVITA
 * Open VitaPad on PSVITA
-* Optional: [Install vJoy driver](https://github.com/njz3/vJoy/releases/download/v2.2.0.0/vJoySetup.2.2.0.signed.exe) on Windows PC for vJoy functionality
+* Optional: [Install vJoy driver](https://github.com/njz3/vJoy/releases/download/v2.2.0.0/vJoySetup.2.2.0.signed.exe) on Windows PC for vJoy functionality. Need to set `VJOY_MODE` to 1 in windows.xml.
+* Optional: [Install ViGEm driver](https://github.com/ViGEm/ViGEmBus/releases/download/setup-v1.16.116/ViGEmBus_Setup_1.16.116.exe) on Windows PC for DualShock 4 emulation. Need to set `VIGEM_MODE` to 1 in windows.xml.
 * Open VitaPad on PC
 * Insert the IP showed on PSVITA on PC
 
@@ -27,6 +28,17 @@ Default mapping:
 - Right Analog = 8,6,4,2
 - Touchscreen = Mouse movement
 - Retrotouch = Left/Right click
+
+Default ViGEm mapping:
+
+- PS button unmapped
+- Select = Share
+- Start = Option
+- Left Front Touchscreen = L1
+- Right Front Touchscreen = R1
+- Left shoulder = L2
+- Right shoulder = R2
+- Rest of buttons are mapped to the expected buttons on DualShock 4
 
 ## Footage
 


### PR DESCRIPTION
The current vJoy emulation has several issues, for example you cannot press L2 and R2 at the same time, and some programs (e.g. Moonlight-qt) cannot properly interpret the input. This PR introduces ViGEm support, which emulates DualShock 4 (I have left the space for XBox emulation if someone wants to add it), and have better compatibility (tested with Moonlight-qt which translates DS4 input to XBox input, also Honkai Impact 3 which has native DS4 support)

Now what's left is to support pressing both L1 and R1 at the same time. This has to be done at the server side since currently it only reads 1 finger touch. Currently I'm not using shoulder button so it is not fixed in this PR. Depending on how frequently I use VitaPad in the coming days (it only became usable for me today with this PR) I might work on disconnection handling and keep-alive, and multi finger touch could be included as a bonus.