### PR TITLE
Added L3/R3 in ViGEm Client

### DIFF
--- a/Client/ViGEm.cpp
+++ b/Client/ViGEm.cpp
@@ -74,13 +74,21 @@ bool vgSubmit(pPadPacket packet)
     {
         report.wButtons = report.wButtons | DS4_BUTTON_SQUARE;
     }
-    if (packet->click & MOUSE_MOV && packet->tx < SCREEN_WIDTH / 2)
+    if (packet->click & MOUSE_MOV && packet->tx < SCREEN_WIDTH / 2 && packet->ty < SCREEN_HEIGHT / 2)
     {
         report.wButtons = report.wButtons | DS4_BUTTON_SHOULDER_LEFT;
     }
-    if (packet->click & MOUSE_MOV && packet->tx >= SCREEN_WIDTH / 2)
+    if (packet->click & MOUSE_MOV && packet->tx >= SCREEN_WIDTH / 2 && packet->ty < SCREEN_HEIGHT / 2)
     {
         report.wButtons = report.wButtons | DS4_BUTTON_SHOULDER_RIGHT;
+    }
+    if (packet->click & MOUSE_MOV && packet->tx < SCREEN_WIDTH / 2 && packet->ty >= SCREEN_HEIGHT / 2)
+    {
+        report.wButtons = report.wButtons | DS4_BUTTON_THUMB_LEFT;
+    }
+    if (packet->click & MOUSE_MOV && packet->tx >= SCREEN_WIDTH / 2 && packet->ty >= SCREEN_HEIGHT / 2)
+    {
+        report.wButtons = report.wButtons | DS4_BUTTON_THUMB_RIGHT;
     }
 
     if (packet->buttons & SCE_CTRL_UP) DS4_SET_DPAD(&report, DS4_BUTTON_DPAD_NORTH);


### PR DESCRIPTION
I need to play Genshin Impact with L3/R3 so here i am. L3/R3 mapped to touchscreen right below L1/R1. Thanks to VitaPad, my PSVita rises from the dead. 